### PR TITLE
Change the menu display from subscriber to author

### DIFF
--- a/src/includes/class-controller.php
+++ b/src/includes/class-controller.php
@@ -32,7 +32,7 @@ class Controller {
 		add_menu_page(
 			esc_html__( 'Reusable Blocks', 'reusable-blocks-admin-menu-option' ),
 			esc_html__( 'Reusable Blocks', 'reusable-blocks-admin-menu-option' ),
-			'read',
+			'delete_published_posts',
 			'edit.php?post_type=wp_block',
 			'',
 			'',


### PR DESCRIPTION
Changed the menu reading from subscriber to author. **Subscriber** and **Contributor** roles do not have the right to create or edit reusable blocks, so it makes no sense to show them this menu.